### PR TITLE
Fixed CGFloat check and Swizzling logic

### DIFF
--- a/EasingSampleApp/EasingSampleApp.xcodeproj/xcuserdata/charlie.xcuserdatad/xcschemes/EasingSampleApp.xcscheme
+++ b/EasingSampleApp/EasingSampleApp.xcodeproj/xcuserdata/charlie.xcuserdatad/xcschemes/EasingSampleApp.xcscheme
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0460"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "018B7285173278AA002FBC58"
+               BuildableName = "EasingSampleApp.app"
+               BlueprintName = "EasingSampleApp"
+               ReferencedContainer = "container:EasingSampleApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      buildConfiguration = "Debug">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "018B7285173278AA002FBC58"
+            BuildableName = "EasingSampleApp.app"
+            BlueprintName = "EasingSampleApp"
+            ReferencedContainer = "container:EasingSampleApp.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </TestAction>
+   <LaunchAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "018B7285173278AA002FBC58"
+            BuildableName = "EasingSampleApp.app"
+            BlueprintName = "EasingSampleApp"
+            ReferencedContainer = "container:EasingSampleApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Release"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "018B7285173278AA002FBC58"
+            BuildableName = "EasingSampleApp.app"
+            BlueprintName = "EasingSampleApp"
+            ReferencedContainer = "container:EasingSampleApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/EasingSampleApp/EasingSampleApp.xcodeproj/xcuserdata/charlie.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/EasingSampleApp/EasingSampleApp.xcodeproj/xcuserdata/charlie.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>SchemeUserState</key>
+	<dict>
+		<key>EasingSampleApp.xcscheme</key>
+		<dict>
+			<key>orderHint</key>
+			<integer>0</integer>
+		</dict>
+	</dict>
+	<key>SuppressBuildableAutocreation</key>
+	<dict>
+		<key>018B7285173278AA002FBC58</key>
+		<dict>
+			<key>primary</key>
+			<true/>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/EasingSampleApp/Pods/Pods.xcodeproj/xcuserdata/charlie.xcuserdatad/xcschemes/Pods.xcscheme
+++ b/EasingSampleApp/Pods/Pods.xcodeproj/xcuserdata/charlie.xcuserdatad/xcschemes/Pods.xcscheme
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0460"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "81AD438CB6E74AE591E42109"
+               BuildableName = "libPods.a"
+               BlueprintName = "Pods"
+               ReferencedContainer = "container:Pods.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      buildConfiguration = "Debug">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      allowLocationSimulation = "YES">
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Release"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/EasingSampleApp/Pods/Pods.xcodeproj/xcuserdata/charlie.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/EasingSampleApp/Pods/Pods.xcodeproj/xcuserdata/charlie.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>SchemeUserState</key>
+	<dict>
+		<key>Pods.xcscheme</key>
+		<dict>
+			<key>orderHint</key>
+			<integer>1</integer>
+		</dict>
+	</dict>
+	<key>SuppressBuildableAutocreation</key>
+	<dict>
+		<key>81AD438CB6E74AE591E42109</key>
+		<dict>
+			<key>primary</key>
+			<true/>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/UIView+EasingFunctions/UIView+EasingFunctions.m
+++ b/UIView+EasingFunctions/UIView+EasingFunctions.m
@@ -188,6 +188,8 @@ static BOOL Swizzled = NO;
         Method substitute = class_getInstanceMethod(CALayer.class, @selector(easing_addAnimation:forKey:));
 
         method_exchangeImplementations(original, substitute);
+
+        Swizzled = YES;
     }
 
     NSMutableDictionary *easingFunctions = [self valueForKey:LayerEasingFunctionsKey];

--- a/UIView+EasingFunctions/UIView+EasingFunctions.m
+++ b/UIView+EasingFunctions/UIView+EasingFunctions.m
@@ -250,8 +250,9 @@ static BOOL Swizzled = NO;
             }
             
             /* CGFloat */
-            else if (strcmp(@encode(CGFloat), [fromValue objCType]) == 0) {
-                
+            // check for BOTH float and double
+            else if (strcmp("f", [fromValue objCType]) == 0 || strcmp("d", [fromValue objCType]) == 0) {
+
 #if CGFLOAT_IS_DOUBLE
                 CGFloat from = [(NSNumber *)fromValue doubleValue];
                 CGFloat to = [(NSNumber *)toValue doubleValue];


### PR DESCRIPTION
Original implementation swizzled the addAnimation method every time the first easing function was added to an instance of CALayer, but this only needs to happen once for the whole class. 

Now, the swizzling only happens the first time an easing function is added to CALayer and the swizzle is never undone. If there's a good reason to undo the swizzling (performance, maybe?), then we should use a static counter variable that instances increment/decrement as easing functions are added and removed. Once the counter reaches 0, we can unswizzle.

Also changed the check for the type of the original animation's from value so it catches both floats and doubles as CGFloat.
