### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ Easing functions?
 Installation
 ------------
 
-###Cocoapods###
+###CocoaPods###
 
-[Cocoapods](https://github.com/CocoaPods/CocoaPods) is an Objective-C library manager.
+[CocoaPods](https://github.com/CocoaPods/CocoaPods) is an Objective-C library manager.
 
-Adding UIView+EasingFunctions to your project using Cocoapods is as easy as adding the following line to your `Podfile`: 
+Adding UIView+EasingFunctions to your project using CocoaPods is as easy as adding the following line to your `Podfile`: 
 
 ```ruby
 pod 'UIView+EasingFunctions'


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
